### PR TITLE
ignore tcga_luadlusc unzipped folder in assets/data/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 checkpoints/
 dataset_csvs/
+assets/data/tcga_luadlusc/
 
 tests/data/
 *.pt


### PR DESCRIPTION
I was running the [notebooks/uni_walkthrough.ipynb](https://github.com/mahmoodlab/UNI/blob/main/notebooks/uni_walkthrough.ipynb) notebook, which assumed that the tcga_luadlusc is unzipped inside `assets/data/`. It created many new files for git to track. Maybe this folder can be ignored.