### PR TITLE
Add instructions to install faiss for using protonet.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ pip install --upgrade pip  # enable PEP 660 support
 pip install -e .
 ```
 
+To use [uni/downstream/eval_patch_features/protonet.py](./uni/downstream/eval_patch_features/protonet.py) and run the corresponding part of the [walkthrough notebook](./notebooks/uni_walkthrough.ipynb) you also need to [install faiss](https://github.com/facebookresearch/faiss/blob/main/INSTALL.md).
+
 
 ### 1. Getting access
 Request access to the model weights from the Huggingface model page at: [https://huggingface.co/mahmoodlab/UNI](https://huggingface.co/mahmoodlab/uni).


### PR DESCRIPTION
Dear authors,

`faiss` is unnecessary for using the UNI model unless someone wants to use `uni/downstream/eval_patch_features/protonet.py` and the corresponding part of the walkthrough notebook. I added the link to the official installation instructions.

Best wishes,
George