### PR TITLE
ignore CRC100K unzipped folder in assets/data/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 checkpoints/
 dataset_csvs/
 assets/data/tcga_luadlusc/
+assets/data/CRC100K/
 
 tests/data/
 *.pt


### PR DESCRIPTION
same as https://github.com/mahmoodlab/UNI/pull/3 but for CRC100K (useful for running the crc100k_evaluation.ipynb notebook)