### PR TITLE
Sort-prune-imports

### DIFF
--- a/uni/downstream/eval_patch_features/__init__.py
+++ b/uni/downstream/eval_patch_features/__init__.py
@@ -1,4 +1,4 @@
-from .linear_probe import eval_linear_probe
 from .fewshot import eval_knn
-from .protonet import ProtoNet
+from .linear_probe import eval_linear_probe
 from .metrics import get_eval_metrics, print_metrics
+from .protonet import ProtoNet

--- a/uni/downstream/eval_patch_features/fewshot.py
+++ b/uni/downstream/eval_patch_features/fewshot.py
@@ -4,15 +4,17 @@ Adapted from https://github.com/mbanani/lgssl/blob/df45bae647fc24dce8a6329eb6979
 """
 
 import logging
+from typing import Any, List, Tuple
+
 import numpy as np
 import pandas as pd
+import sklearn.neighbors
 import torch
 from torch.nn.functional import normalize
 from torch.utils.data import Sampler
 from tqdm import tqdm
-import sklearn.neighbors
+
 from .metrics import get_eval_metrics
-from typing import Any, List, Tuple
 
 
 def eval_knn(

--- a/uni/downstream/eval_patch_features/linear_probe.py
+++ b/uni/downstream/eval_patch_features/linear_probe.py
@@ -9,19 +9,16 @@ from __future__ import annotations
 import random
 import time
 from collections import defaultdict
+from typing import Tuple, Dict, Any, List
 from warnings import simplefilter
 
 import torch
 import torch.utils.data
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression as sk_LogisticRegression
+
 from .logistic_regression import LogisticRegression
 from .metrics import get_eval_metrics
-
-from collections import defaultdict
-import random
-from typing import Tuple, Dict, Any, List
-import torch
 
 
 # Silence repeated convergence warnings from scikit-learn logistic regression.

--- a/uni/downstream/eval_patch_features/protonet.py
+++ b/uni/downstream/eval_patch_features/protonet.py
@@ -1,17 +1,15 @@
 """
 Implementation adapted from: https://github.com/mbanani/lgssl/blob/df45bae647fc24dce8a6329eb697944053e9a8a0/lgssl/evaluation/fewshot.py#L9C3-L9C3
 """
-import torch
-import numpy as np
-from torch.nn.functional import normalize
-import faiss
-import pandas as pd
-from threadpoolctl import threadpool_limits
 from typing import Tuple
+
+import faiss
 import numpy as np
-import torch
-import torch
+import pandas as pd
 import sklearn.cluster
+from threadpoolctl import threadpool_limits
+import torch
+from torch.nn.functional import normalize
 
 class ProtoNet:
     """

--- a/uni/downstream/extract_patch_features.py
+++ b/uni/downstream/extract_patch_features.py
@@ -1,7 +1,7 @@
 import numpy as np
-from tqdm import tqdm
 import torch
 import torch.multiprocessing
+from tqdm import tqdm
 
 from ..get_encoder import get_encoder
 

--- a/uni/downstream/utils.py
+++ b/uni/downstream/utils.py
@@ -2,7 +2,6 @@ import pickle
 import datetime
 from tqdm import tqdm
 import logging
-import h5py
 import numpy as np
 
 from PIL.ImageFile import ImageFile

--- a/uni/downstream/utils.py
+++ b/uni/downstream/utils.py
@@ -1,14 +1,13 @@
-import pickle
 import datetime
-from tqdm import tqdm
 import logging
-import numpy as np
-
-from PIL.ImageFile import ImageFile
-from PIL import Image, ImageOps
-from typing import List, Tuple
-from PIL import Image
+import pickle
 from typing import Any, Dict, Union
+from typing import List, Tuple
+
+import numpy as np
+from PIL import Image, ImageOps
+from PIL.ImageFile import ImageFile
+from tqdm import tqdm
 
 def scale_img(
         img: ImageFile, 

--- a/uni/get_encoder/get_encoder.py
+++ b/uni/get_encoder/get_encoder.py
@@ -1,12 +1,12 @@
 import os
 import logging
 
+import timm
 import torch
 import torch.nn as nn
 from torchvision import transforms
 
 from .models.resnet50_trunc import resnet50_trunc_imagenet
-import timm
 
 def get_norm_constants(which_img_norm: str = 'imagenet'):
     constants_zoo = {

--- a/uni/get_encoder/models/resnet50_trunc.py
+++ b/uni/get_encoder/models/resnet50_trunc.py
@@ -1,8 +1,8 @@
 # modified from Pytorch official resnet.py
-import torch.nn as nn
-import torch.utils.model_zoo as model_zoo
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
+import torch.utils.model_zoo as model_zoo
 
 __all__ = ['ResNet', 'resnet18', 'resnet34', 'resnet50', 'resnet101',
            'resnet152']


### PR DESCRIPTION
1. removed h5py import because it was never used, but was introducing a dependency

2. removed duplicate imports, e.g. torch was imported multiple times in some files

3. sorted imports in order: built-in, installed, locally-defined