### PR TITLE
Update setup.py in concordance with huggingface page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,20 +3,27 @@ from codecs import open
 from os import path
 
 setup(
-    name='uni',
-    version='0.1.0',
-    description='UNI',
-    url='https://github.com/mahmoodlab/UNI',
-    author='RJC,MYL,TD',
-    author_email='',
-    license='CC BY-NC 4.0',
-    packages=find_packages(exclude=['__dep__', 'assets']),
-    install_requires=["torch>=2.0.1", "torchvision", "timm==0.9.8", 
-                      "numpy", "pandas", "scikit-learn", "tqdm",
-                      "transformers"],
-
-    classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: CC BY-NC 4.0",
-]
+    name="uni",
+    version="0.1.0",
+    description="UNI",
+    url="https://github.com/mahmoodlab/UNI",
+    author="RJC,MYL,TD",
+    author_email="",
+    license="CC BY-NC 4.0",
+    packages=find_packages(exclude=["__dep__", "assets"]),
+    install_requires=[
+        "torch>=2.0.1",
+        "torchvision",
+        "timm>=0.9.8",
+        "numpy",
+        "pandas",
+        "scikit-learn",
+        "tqdm",
+        "transformers",
+        "xformers>=0.0.18",
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: CC BY-NC 4.0",
+    ],
 )


### PR DESCRIPTION
Before, the timm version was hard-coded to 0.9.8, which made it impossible to install uni alongside other models requiring newer versions of timm. Making the requirement inclusive of future versions (as suggested on the model's [huggingface page][hf] solves this problem.

[hf]: https://huggingface.co/MahmoodLab/UNI#software-dependencies